### PR TITLE
Fix missing wcs import

### DIFF
--- a/modules/astrometry.py
+++ b/modules/astrometry.py
@@ -34,6 +34,7 @@ import os
 from pathlib import Path
 import traceback
 from astropy.io import fits
+from astropy import wcs
 import time
 import subprocess
 from astropy.table import Table


### PR DESCRIPTION
## Summary
- fix NameError in `run_astrometry_net` by importing `wcs`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68479b0d67fc832fb9c3d4535e8d85e9