### PR TITLE
Fix additional missing base paths

### DIFF
--- a/modules/platesolving.py
+++ b/modules/platesolving.py
@@ -30,10 +30,12 @@ Paper on OSSPipeline: https://rtsre.org/index.php/rtsre/article/view/12/12
 
 import numpy as np
 import logging
+from pathlib import Path
 
-def crop_images_for_wcs_flatness(file):
+def crop_images_for_wcs_flatness(file, base):
 
-    imagedata=np.load('workingdirectory/' +file)
+    path = Path(base) / 'workingdirectory' / file
+    imagedata=np.load(path)
 
     # We are actually going to crop the image
     # So we need to adjust the size here also.
@@ -44,15 +46,15 @@ def crop_images_for_wcs_flatness(file):
 
     imagedata = imagedata[cropvalue_w:-cropvalue_w,cropvalue_h:-cropvalue_h]
 
-    np.save('workingdirectory/' +file, imagedata)
+    np.save(path, imagedata)
     return cropvalue_h,cropvalue_w
 
 ##### Crop single images to get rid of regions with probably dodgy wcs values
 ##### For both individual images, but also so strange stretches don't emerge in stacks
 
-def multiprocess_crop_images_for_flatness(header):
+def multiprocess_crop_images_for_flatness(header, base):
 
-    cropvalue_h,cropvalue_w=crop_images_for_wcs_flatness(header['ORIGNAME'].replace('.fits.fz','.npy').replace('.fits','.npy'))
+    cropvalue_h,cropvalue_w=crop_images_for_wcs_flatness(header['ORIGNAME'].replace('.fits.fz','.npy').replace('.fits','.npy'), base)
 
     if any("CRPIX1" in s for s in header.keys()):
         header['CRPIX1']=header['CRPIX1']-cropvalue_h

--- a/modules/smart_stack.py
+++ b/modules/smart_stack.py
@@ -36,6 +36,7 @@ import bottleneck as bn
 import math
 import os
 from multiprocessing.pool import Pool
+from pathlib import Path
 import astropy.units as u
 from reproject.mosaicking import find_optimal_celestial_wcs
 import psutil
@@ -928,8 +929,11 @@ def smart_stack(fileList, telescope, basedirectory, memmappath, calibration_dire
     logging.info (newName.replace(' ','').replace('_NP_NP_','_'))
     # Report number of nans in array
     logging.info ("Number of nan pixels in image array: " + str(np.count_nonzero(np.isnan(finalImage))))
-    fits.writeto("sstacksdirectory/" + newName.replace(' ','').replace('_NP_NP_','_'), (np.asarray(finalImage).astype(np.float32)), newheader, output_verify='silentfix')
-    fits.writeto("sstacksdirectory/" + 'variance_'+newName.replace(' ','').replace('_NP_NP_','_'), (np.asarray(variance_finalImage).astype(np.float32)), newheader, output_verify='silentfix')
+    base = Path(basedirectory)
+    dest = base / 'sstacksdirectory' / newName.replace(' ','').replace('_NP_NP_','_')
+    fits.writeto(dest, (np.asarray(finalImage).astype(np.float32)), newheader, output_verify='silentfix')
+    var_dest = base / 'sstacksdirectory' / ('variance_' + newName.replace(' ','').replace('_NP_NP_','_'))
+    fits.writeto(var_dest, (np.asarray(variance_finalImage).astype(np.float32)), newheader, output_verify='silentfix')
     
     del finalImage
     del variance_finalImage


### PR DESCRIPTION
## Summary
- use base directory for smart-stack globbing and preview generation
- write final smart-stack images into base output directory
- ensure smart_stack writes to base sstacksdirectory
- save single images into base output directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f7988c62c832f85194c32159bdea3