### PR TITLE
Fix OBSID for LCOGT headers

### DIFF
--- a/modules/header_functions.py
+++ b/modules/header_functions.py
@@ -189,6 +189,10 @@ def value_add_header(header, telescope):
            
     if not any("ORIGIN" in s for s in header.keys()):
         header['ORIGIN'] = 'Unknown'
+
+    # When the data comes from LCOGT, standardise the observation ID early
+    if header.get('ORIGIN', '').lower() == 'lcogt':
+        header['OBSID'] = 'LCO'
     
     if not any("HEIGHT" in s for s in header.keys()):
         if any("ALT-OBS" in s for s in header.keys()):


### PR DESCRIPTION
## Summary
- set `OBSID` to `LCO` if origin is `LCOGT`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850a25cd904832fa444b4e173005e92