### PR TITLE
Fix FWHM errors on variance stacks

### DIFF
--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -461,13 +461,19 @@ def construct_images(headers, human_names, cfg, args, base):
     wait_for_resources()
     # Final smart-stack image construction
     fits_ss = glob.glob(str(Path(base) / 'sstacksdirectory' / '*.fits'))
-    # remove variance frames from final image construction entirely
+    # collect any variance frames; these will be copied out but not processed
+    variance_frames = [f for f in fits_ss if os.path.basename(f).startswith('variance_')]
     fits_ss = [f for f in fits_ss if not os.path.basename(f).startswith('variance_')]
     
     n2 = max(1, min(math.floor(cpu*0.25), len(fits_ss)))
     with Pool(n2) as p:
         tasks = [(f, base) for f in fits_ss]
         p.starmap(multiprocess_final_image_construction_smartstack, tasks)
+
+    # Copy variance frames directly to outputdirectory without processing
+    for vf in variance_frames:
+        dest = Path(base) / 'outputdirectory' / os.path.basename(vf)
+        shutil.copy(vf, dest)
 
     # Previews
     wait_for_resources()

--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -461,6 +461,8 @@ def construct_images(headers, human_names, cfg, args, base):
     wait_for_resources()
     # Final smart-stack image construction
     fits_ss = glob.glob(str(Path(base) / 'sstacksdirectory' / '*.fits'))
+    # remove variance frames from final image construction entirely
+    fits_ss = [f for f in fits_ss if not os.path.basename(f).startswith('variance_')]
     
     n2 = max(1, min(math.floor(cpu*0.25), len(fits_ss)))
     with Pool(n2) as p:

--- a/modules/final_image.py
+++ b/modules/final_image.py
@@ -55,18 +55,19 @@ def multiprocess_final_image_construction_smartstack(file, base):
     
     imagedata=interpolate_replace_nans(imagedata,kernel)
 
-    # Calculate Image FWHM
-    sepimg=copy.deepcopy(imagedata).byteswap().newbyteorder()
-    try:
-        bkg = sep.Background(sepimg, bw=32, bh=32, fw=3, fh=3)
-        bkg.subfrom(sepimg)
-    except:
-        logging.info ("Failed background (usually flat) for image: " + str(file))
-        
-    try:
-        tempheader=calculate_image_fwhm(sepimg, tempheader)
-    except:
-        logging.info ("Failed FWHM (usually blank) for image: " + str(file))
+    # Calculate Image FWHM unless this is a variance frame
+    if not Path(file).name.startswith('variance_'):
+        sepimg=copy.deepcopy(imagedata).byteswap().newbyteorder()
+        try:
+            bkg = sep.Background(sepimg, bw=32, bh=32, fw=3, fh=3)
+            bkg.subfrom(sepimg)
+        except Exception:
+            logging.info("Failed background (usually flat) for image: %s", file)
+
+        try:
+            tempheader = calculate_image_fwhm(sepimg, tempheader)
+        except Exception:
+            logging.info("Failed FWHM (usually blank) for image: %s", file)
 
     # Offset bias pedestal
     imagedata = imagedata + 200


### PR DESCRIPTION
## Summary
- avoid calculating FWHM for `variance_` smart-stack files
- skip variance frames when generating final smart stack images

## Testing
- `python3 -m py_compile modules/final_image.py EVApipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6852342cafec832fb6a2b37474085c27