### PR TITLE
Copy effective exposure headers into BZESK smartstacks

### DIFF
--- a/modules/final_image.py
+++ b/modules/final_image.py
@@ -556,6 +556,16 @@ def make_banzai_file_out_of_EVA(file, telescope, basedirectory, calibration_dire
 
             banzai_image_header['MJD-OBS'] = ( eva_image_header['MJD-OBS'] ,'[UTC days] Start date/time (Modified Julian Date)')
             banzai_image_header['EXPTIME'] = ( eva_image_header['EXPTIME'],'[s] Actual exposure length')
+            if 'EFFEXPT' in eva_image_header:
+                banzai_image_header['EFFEXPT'] = (
+                    eva_image_header['EFFEXPT'],
+                    '[s] Effective open shutter exposure time',
+                )
+            if 'EFFEXPN' in eva_image_header:
+                banzai_image_header['EFFEXPN'] = (
+                    eva_image_header['EFFEXPN'],
+                    'Number of exposures contributing to the stack',
+                )
             try:
                 banzai_image_header['REQTIME'] = ( eva_image_header['REQTIME'] ,'[s] Requested exposure length')
             except:


### PR DESCRIPTION
## Summary
- include EFFEXPT and EFFEXPN when building BZESKSmSTACK headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854be2e5cc8832f809000301ead4606