### PR TITLE
Add default OSCCAM False

### DIFF
--- a/modules/header_functions.py
+++ b/modules/header_functions.py
@@ -119,6 +119,9 @@ def value_add_header(header, telescope):
     if not any("RDNOISE" in s for s in header.keys()):
         header['RDNOISE']=10.0
 
+    if not any("OSCCAM" in s for s in header.keys()):
+        header['OSCCAM'] = False
+
     header['OBJECT']=str(header['OBJECT'].replace('(','').replace(')',''))
     header['OBJECT']=str(header['OBJECT'].replace(' ',''))
     header['OBJECT']=str(header['OBJECT'].replace('1of2','').replace('2of2','').replace('1of3','').replace('2of3','').replace('3of3',''))


### PR DESCRIPTION
## Summary
- ensure `OSCCAM` is defined when missing

## Testing
- `python3 -m py_compile modules/header_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68563f892508832fbbd70a94e09e9a84