### PR TITLE
Fix telescope parsing for LCO

### DIFF
--- a/modules/header_functions.py
+++ b/modules/header_functions.py
@@ -87,6 +87,10 @@ def value_add_header(header, telescope):
         dict: Updated FITS header.
     """
 
+    # Normalize telescope parameter to avoid issues with trailing whitespace or
+    # case sensitivity when comparing against 'lco'
+    telescope = telescope.strip().lower()
+
     header['BZERO']=0
     header['BSCALE']=1
     if not any("PEDESTAL" in s for s in header.keys()):


### PR DESCRIPTION
## Summary
- standardize telescope parameter when enriching FITS headers

## Testing
- `python3 -m py_compile modules/header_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68565c9bb14c832fa076dc57e37a47ca