### PR TITLE
Fix SMARTSTK injection location

### DIFF
--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -475,6 +475,16 @@ def enrich_build(headers, cfg, args, base):
     with Pool() as p:
         tasks = [(h, base) for h in headers]
         headers = p.starmap(multiprocess_crop_images_for_flatness, tasks)
+
+    # Ensure SMARTSTK exists before files are organised into smartstack
+    # directories. Some historical LCO headers may lack this field.
+    if args.telescope.strip().lower() == 'lco':
+        for h in headers:
+            if 'SMARTSTK' not in h:
+                reqnum = str(h.get('REQNUM', '')).strip()
+                filt = str(h.get('FILTER', '')).split('_')[-1]
+                h['SMARTSTK'] = 'lco' + reqnum + filt
+
     return headers, human_names
 
 def construct_images(headers, human_names, cfg, args, base):


### PR DESCRIPTION
## Summary
- keep SMARTSTK enrichment in `enrich_build`
- revert earlier injection logic in `smart_stack`

## Testing
- `python3 -m py_compile EVApipeline.py modules/smart_stack.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68567fc81018832fa99c7febbf584c06