### PR TITLE
Limit sources used in quickanalysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ to a ``successful_token`` directory.
 The pipeline automatically detects this token file when running in
 ``generic`` mode.
 
+When generating quickanalysis QAJSON files, only the brightest 500 sources
+are profiled if more than 100,000 detections are present in the photometry
+catalogue. This keeps the quickanalysis files manageable on extremely
+dense fields.
+


### PR DESCRIPTION
## Summary
- document quickanalysis limit
- limit to brightest 500 sources when more than 100,000 detections are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857049abd1c832fad869b16dcdbd065