### PR TITLE
Fix missing quickanalysis local folder creation

### DIFF
--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -178,7 +178,10 @@ def prepare_local_output_dirs(files, cfg):
 
     for d in dayobs_set:
         base = Path(cfg['local_output_folder']) / d
-        for sub in ['fits', 'photometry', 'pngs', 'previews', 'thumbnails']:
+        for sub in [
+            'fits', 'photometry', 'pngs', 'previews', 'thumbnails',
+            'quickanalysis'
+        ]:
             (base / sub).mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- ensure quickanalysis directories exist in local output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68571917bae8832fa9f2f4b2497a2fa4