### PR TITLE
Create quickanalysis dir for local copies

### DIFF
--- a/modules/archive.py
+++ b/modules/archive.py
@@ -257,7 +257,16 @@ def archive_preparer(file, largedataset_output_folder, shortexposure_output_fold
         if os.path.exists(tempfilename):
 
             if local_copy:
-                shutil.copy(tempfilename, local_output_folder + '/' + dayobs + '/quickanalysis/' + tempfilename.split('/')[-1].replace('.qajson',seq_number+'.qajson'))
+                os.makedirs(os.path.join(local_output_folder, dayobs, 'quickanalysis'), exist_ok=True)
+                shutil.copy(
+                    tempfilename,
+                    os.path.join(
+                        local_output_folder,
+                        dayobs,
+                        'quickanalysis',
+                        tempfilename.split('/')[-1].replace('.qajson', seq_number + '.qajson')
+                    )
+                )
 
             headerdict['RLEVEL'] = 72
             try:


### PR DESCRIPTION
## Summary
- create the `quickanalysis` directory if missing before copying QA JSON files

## Testing
- `python3 -m py_compile modules/archive.py`
- `python3 -m py_compile EVApipeline.py`
- `python3 -m py_compile modules/final_image.py`

------
https://chatgpt.com/codex/tasks/task_e_6857e898c2f8832fb7c959d6c618da81