### PR TITLE
Update token archiving

### DIFF
--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -299,7 +299,11 @@ def collect_files(cfg, args, base, tokenfile=None):
             if arrived_ratio < 90 and missing_count > 2:
                 remove_token = token_is_older_than(Path(base).name)
                 if remove_token and tokenfile:
-                    move_token_to_failed(tokenfile)
+                    move_token_to_failed(
+                        tokenfile,
+                        cfg['local_output_folder'],
+                        cfg['localptrarchivefolder']
+                    )
                 cleanup_and_exit(
                     os.path.expanduser('~'),
                     base,
@@ -709,7 +713,11 @@ def main():
 
     if not args.rundate == 'localfolder':
         if tokenfile:
-            move_token_to_successful(tokenfile)
+            move_token_to_successful(
+                tokenfile,
+                cfg['local_output_folder'],
+                cfg['localptrarchivefolder']
+            )
         cleanup_and_exit(
             os.path.expanduser('~'),
             base,

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ June 2025: photometry subprocesses now run in their temporary
 directories so that the bundled `default.param` and `default.psfex`
 configuration files are found correctly.
 
-When the pipeline cannot locate the expected FITS files and the token is
-older than 30 days, the token file is moved into a ``failed_tokens``
-folder for later inspection.
+When the pipeline cannot locate the expected FITS files and the token
+in ``localptrarchive/tokens`` is older than 30 days, the pipeline moves
+that token from ``cfg['localptrarchivefolder']/tokens`` into the
+``EVAreducedfiles/failedtokens`` directory for later inspection.
 
-Upon successful completion, any token file present is instead moved
-to a ``successful_token`` directory.
+Upon successful completion, the token file stored in
+``cfg['localptrarchivefolder']/tokens`` is moved to
+``EVAreducedfiles/successfultokens``.
 
 The pipeline automatically detects this token file when running in
 ``generic`` mode.

--- a/modules/general_helpers.py
+++ b/modules/general_helpers.py
@@ -426,11 +426,16 @@ def token_is_older_than(token_name, days=30):
 
     return (datetime.utcnow().date() - tdate) > timedelta(days=days)
 
-def move_token_to_failed(token_file):
-    """Move ``token_file`` into a ``failed_tokens`` directory next to it."""
+def move_token_to_failed(token_file, output_root=None, token_root=None):
+    """Move ``token_file`` from the ``tokens`` directory into ``failedtokens``."""
 
     tpath = Path(token_file)
-    dest_dir = tpath.parent / 'failed_tokens'
+    if token_root:
+        tpath = Path(token_root) / 'tokens' / tpath.name
+    if output_root:
+        dest_dir = Path(output_root) / 'failedtokens'
+    else:
+        dest_dir = tpath.parent / 'failed_tokens'
     try:
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(tpath), dest_dir / tpath.name)
@@ -438,11 +443,16 @@ def move_token_to_failed(token_file):
     except Exception as e:
         logging.info(f"Failed to move token file '{tpath}': {e}")
 
-def move_token_to_successful(token_file):
-    """Move ``token_file`` into a ``successful_token`` directory next to it."""
+def move_token_to_successful(token_file, output_root=None, token_root=None):
+    """Move ``token_file`` from the ``tokens`` directory into ``successfultokens``."""
 
     tpath = Path(token_file)
-    dest_dir = tpath.parent / 'successful_token'
+    if token_root:
+        tpath = Path(token_root) / 'tokens' / tpath.name
+    if output_root:
+        dest_dir = Path(output_root) / 'successfultokens'
+    else:
+        dest_dir = tpath.parent / 'successful_token'
     try:
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(tpath), dest_dir / tpath.name)


### PR DESCRIPTION
## Summary
- move completed tokens from the archive `tokens` directory into `EVAreducedfiles/successfultokens`
- move failed tokens from the archive `tokens` directory into `EVAreducedfiles/failedtokens`
- document token path handling

## Testing
- `pytest -q`
- `python -m py_compile EVApipeline.py modules/general_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_685a0aab27d8832f85db82fe03533a6c