### PR TITLE
Handle tokenfile in generic mode

### DIFF
--- a/EVApipeline.py
+++ b/EVApipeline.py
@@ -707,8 +707,18 @@ def main():
     # Make BANZAI files
     wait_for_resources_cfg(cfg)
     do_banzai_file_type(cfg, args.telescope, base)
-        
+
     do_archive(cfg, base)
+
+    if args.mode == 'generic':
+        if tokenfile:
+            try:
+                os.remove(tokenfile)
+                logging.info('Removed tokenfile %s', tokenfile)
+            except Exception as e:
+                logging.warning('Failed to remove tokenfile %s: %s', tokenfile, e)
+        else:
+            logging.info('No tokenfile found to remove')
 
 
     if not args.rundate == 'localfolder':


### PR DESCRIPTION
## Summary
- delete tokenfile when running in `generic` mode
- log success or failure of deletion

## Testing
- `python3 -m py_compile EVApipeline.py`
- `python3 -m py_compile modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685b173ce4dc832faecf04508ccbaf16